### PR TITLE
fix: add timeout for wait kernel ready

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ feature = ["local"]
 
 [tool.hatch.envs.hatch-test]
 parallel = true
+extra-args = ["--dist","loadfile"]
 extra-dependencies = [
   "pppybox[local]",
   "pytest-asyncio",
@@ -87,3 +88,7 @@ exclude_lines = [
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
 ]
+
+[tool.ruff]
+# Allow lines to be as long as 120.
+line-length = 120

--- a/src/pybox/local.py
+++ b/src/pybox/local.py
@@ -31,7 +31,7 @@ class LocalPyBox(BasePyBox):
 
     def run(self, code: str, timeout: int = 60) -> PyBoxOut:
         if not self.client.channels_running:
-            self.client.wait_for_ready()
+            self.client.wait_for_ready(timeout=timeout)
 
         msg_id = self.client.execute(code)
         self.__wait_for_execute_reply(msg_id, timeout=timeout)


### PR DESCRIPTION
- Add a timeout for waiting for the kernel to be ready.
- add extra-args for hatch tests
- Set the default line-length to 120 to align the pre-commit ruff format with hatch fmt.